### PR TITLE
rename PhpunitResultParser

### DIFF
--- a/CakePhpTestEngine.php
+++ b/CakePhpTestEngine.php
@@ -117,7 +117,7 @@ final class CakePhpTestEngine extends ArcanistUnitTestEngine {
      */
     private function parseTestResults($path, $json_tmp, $clover_tmp) {
         $test_results = Filesystem::readFile($json_tmp);
-        return id(new PhpunitResultParser())
+        return id(new ArcanistPhpunitTestResultParser())
             ->setEnableCoverage($this->getEnableCoverage())
             ->setProjectRoot($this->projectRoot)
             ->setCoverageFile($clover_tmp)


### PR DESCRIPTION
On Jan 4 the class was moved and renamed from arcanist/src/unit/engine/PhpunitResultParser.php to arcanist/src/unit/parser/ArcanistPhpunitTestResultParser.php
